### PR TITLE
Fixed Clang Compilation - Fixes #9

### DIFF
--- a/src/api/dcps/isocpp/include/dds/pub/DataWriter.hpp
+++ b/src/api/dcps/isocpp/include/dds/pub/DataWriter.hpp
@@ -634,7 +634,7 @@ public:
     close()
     {
         this->delegate()->close();
-        dds::pub::AnyDataWriter adw(*this);
+        dds::pub::AnyDataWriter &adw(*this);
         org::opensplice::core::retain_remove<dds::pub::AnyDataWriter>(adw);
     }
 
@@ -648,7 +648,7 @@ public:
     retain()
     {
         this->delegate()->retain();
-        dds::pub::AnyDataWriter adr(*this);
+        dds::pub::AnyDataWriter &adr(*this);
         org::opensplice::core::retain_add<dds::pub::AnyDataWriter>(adr);
     }
 

--- a/src/api/dcps/isocpp/include/dds/sub/TDataReader.hpp
+++ b/src/api/dcps/isocpp/include/dds/sub/TDataReader.hpp
@@ -933,7 +933,7 @@ private:
         try
         {
             this->delegate()->close();
-            dds::sub::AnyDataReader adr(*this);
+            dds::sub::AnyDataReader &adr(*this);
             org::opensplice::core::retain_remove<dds::sub::AnyDataReader>(adr);
         }
         catch(int i)
@@ -952,7 +952,7 @@ private:
     retain()
     {
         this->delegate()->retain();
-        dds::sub::AnyDataReader adr(*this);
+        dds::sub::AnyDataReader &adr(*this);
         org::opensplice::core::retain_add<dds::sub::AnyDataReader>(adr);
     }
 #ifdef OSPL_2893_COMPILER_BUG

--- a/src/api/dcps/isocpp/include/dds/topic/TTopic.hpp
+++ b/src/api/dcps/isocpp/include/dds/topic/TTopic.hpp
@@ -180,7 +180,7 @@ void
 Topic<T, DELEGATE>::close()
 {
     this->delegate()->close();
-    dds::topic::AnyTopic at(*this);
+    dds::topic::AnyTopic &at(*this);
     org::opensplice::core::retain_remove<dds::topic::AnyTopic>(at);
 }
 
@@ -189,7 +189,7 @@ void
 Topic<T, DELEGATE>::retain()
 {
     this->delegate()->retain();
-    dds::topic::AnyTopic at(*this);
+    dds::topic::AnyTopic &at(*this);
     org::opensplice::core::retain_add<dds::topic::AnyTopic>(at);
 }
 


### PR DESCRIPTION
Clang compilation was failing due to cyclical dependencies causing incomplete types. Issue is appropriately solved by allocating responsible instances of AnyDataReader, AnyDataWriter, and AnyTopic on the heap and relying on cleanup to occur when retention logic executes (Retain.hpp). This fixes issue #9.
