### PR TITLE
Fix compile error on OS X

### DIFF
--- a/src/api/dcps/isocpp/include/dds/pub/AnyDataWriter.hpp
+++ b/src/api/dcps/isocpp/include/dds/pub/AnyDataWriter.hpp
@@ -33,6 +33,12 @@ inline AnyDataWriter::AnyDataWriter(const dds::core::null_type&)
 {
 }
 
+template <typename T> std::unique_ptr<AnyDataWriter>
+create_AnyDataWriter(const dds::pub::DataWriter<T>& dw)
+{
+    return std::unique_ptr<AnyDataWriter>(new AnyDataWriter(dw));
+}
+
 template <typename T>
 AnyDataWriter::AnyDataWriter(const dds::pub::DataWriter<T>& dw)
     : holder_(new dds::pub::detail::DWHolder<T>(dw)) { }

--- a/src/api/dcps/isocpp/include/dds/pub/DataWriter.hpp
+++ b/src/api/dcps/isocpp/include/dds/pub/DataWriter.hpp
@@ -32,6 +32,9 @@ namespace pub
 {
 
 class AnyDataWriter;
+template <typename T> std::unique_ptr<AnyDataWriter>
+create_AnyDataWriter(const dds::pub::DataWriter<T>& dw);
+
 #ifdef OSPL_2893_COMPILER_BUG
 #define DELEGATE dds::pub::detail::DataWriter
 template <typename T>
@@ -634,8 +637,8 @@ public:
     close()
     {
         this->delegate()->close();
-        dds::pub::AnyDataWriter adw(*this);
-        org::opensplice::core::retain_remove<dds::pub::AnyDataWriter>(adw);
+        std::unique_ptr<AnyDataWriter> adw = create_AnyDataWriter(*this);
+        org::opensplice::core::retain_remove<dds::pub::AnyDataWriter>(*adw);
     }
 
 #ifndef OSPL_2893_COMPILER_BUG
@@ -648,8 +651,8 @@ public:
     retain()
     {
         this->delegate()->retain();
-        dds::pub::AnyDataWriter adr(*this);
-        org::opensplice::core::retain_add<dds::pub::AnyDataWriter>(adr);
+        std::unique_ptr<AnyDataWriter> adw = create_AnyDataWriter(*this);
+        org::opensplice::core::retain_add<dds::pub::AnyDataWriter>(*adw);
     }
 
 #ifdef OSPL_2893_COMPILER_BUG

--- a/src/api/dcps/isocpp/include/dds/sub/AnyDataReader.hpp
+++ b/src/api/dcps/isocpp/include/dds/sub/AnyDataReader.hpp
@@ -32,6 +32,12 @@ inline AnyDataReader::AnyDataReader(const dds::core::null_type&)
 {
 }
 
+template <typename T> std::unique_ptr<AnyDataReader>
+create_AnyDataReader(const dds::sub::DataReader<T>& dr)
+{
+    return std::unique_ptr<AnyDataReader>(new AnyDataReader(dr));
+}
+
 template <typename T>
 AnyDataReader::AnyDataReader(const dds::sub::DataReader<T>& dr)
     : holder_(new detail::DRHolder<T>(dr)) { }

--- a/src/api/dcps/isocpp/include/dds/sub/TDataReader.hpp
+++ b/src/api/dcps/isocpp/include/dds/sub/TDataReader.hpp
@@ -32,6 +32,9 @@ namespace sub
 {
 
 class AnyDataReader;
+template <typename T> std::unique_ptr<AnyDataReader>
+create_AnyDataReader(const dds::sub::DataReader<T>& dr);
+
 //--------------------------------------------------------------------------------
 //  DATAREADER
 //--------------------------------------------------------------------------------
@@ -933,8 +936,8 @@ private:
         try
         {
             this->delegate()->close();
-            dds::sub::AnyDataReader adr(*this);
-            org::opensplice::core::retain_remove<dds::sub::AnyDataReader>(adr);
+            std::unique_ptr<AnyDataReader> adr = create_AnyDataReader(*this);
+            org::opensplice::core::retain_remove<dds::sub::AnyDataReader>(*adr);
         }
         catch(int i)
         {
@@ -952,8 +955,8 @@ private:
     retain()
     {
         this->delegate()->retain();
-        dds::sub::AnyDataReader adr(*this);
-        org::opensplice::core::retain_add<dds::sub::AnyDataReader>(adr);
+        std::unique_ptr<AnyDataReader> adr = create_AnyDataReader(*this);
+        org::opensplice::core::retain_add<dds::sub::AnyDataReader>(*adr);
     }
 #ifdef OSPL_2893_COMPILER_BUG
 public:

--- a/src/api/dcps/isocpp/include/dds/topic/AnyTopic.hpp
+++ b/src/api/dcps/isocpp/include/dds/topic/AnyTopic.hpp
@@ -27,6 +27,12 @@ namespace dds
 namespace topic
 {
 
+template <typename T> std::unique_ptr<AnyTopic>
+create_AnyTopic(const dds::topic::Topic<T>& t)
+{
+  return std::unique_ptr<AnyTopic>(new AnyTopic(t));
+}
+
 template <typename T>
 AnyTopic::AnyTopic(const dds::topic::Topic<T>& t): holder_(new detail::THolder<T>(t)) { }
 

--- a/src/api/dcps/isocpp/include/dds/topic/TTopic.hpp
+++ b/src/api/dcps/isocpp/include/dds/topic/TTopic.hpp
@@ -31,6 +31,8 @@ namespace topic
 {
 
 class AnyTopic;
+template <typename T> std::unique_ptr<AnyTopic>
+create_AnyTopic(const dds::topic::Topic<T>& t);
 
 template <typename T, template <typename Q> class DELEGATE>
 Topic<T, DELEGATE>::Topic(const dds::domain::DomainParticipant& dp,
@@ -180,8 +182,8 @@ void
 Topic<T, DELEGATE>::close()
 {
     this->delegate()->close();
-    dds::topic::AnyTopic at(*this);
-    org::opensplice::core::retain_remove<dds::topic::AnyTopic>(at);
+    std::unique_ptr<AnyTopic> at = create_AnyTopic(*this);
+    org::opensplice::core::retain_remove<dds::topic::AnyTopic>(*at);
 }
 
 template <typename T, template <typename Q> class DELEGATE>
@@ -189,8 +191,8 @@ void
 Topic<T, DELEGATE>::retain()
 {
     this->delegate()->retain();
-    dds::topic::AnyTopic at(*this);
-    org::opensplice::core::retain_add<dds::topic::AnyTopic>(at);
+    std::unique_ptr<AnyTopic> at = create_AnyTopic(*this);
+    org::opensplice::core::retain_add<dds::topic::AnyTopic>(*at);
 }
 
 }


### PR DESCRIPTION
Hi, I was building 6.4.0 on my macbook using `x86_64.darwin10_clang-release` (but also affects `x86_64.darwin10_clang-dev`) and I ran into three separate compile issues, all of which can be generalized to this:

```
In file included from code/dds/domain/DomainParticipantListener.cpp:17:
In file included from include/dds/domain/DomainParticipantListener.hpp:22:
In file included from include/spec/dds/domain/DomainParticipantListener.hpp:22:
In file included from include/dds/pub/PublisherListener.hpp:22:
In file included from include/spec/dds/pub/PublisherListener.hpp:22:
In file included from include/dds/pub/AnyDataWriterListener.hpp:22:
In file included from include/spec/dds/pub/AnyDataWriterListener.hpp:22:
In file included from include/dds/pub/AnyDataWriter.hpp:22:
In file included from include/spec/dds/pub/AnyDataWriter.hpp:25:
In file included from include/dds/pub/detail/AnyDataWriter.hpp:24:
include/dds/pub/DataWriter.hpp:637:33: error: variable has incomplete type 'dds::pub::AnyDataWriter'
        dds::pub::AnyDataWriter adw(*this);
                                ^
include/dds/pub/DataWriter.hpp:34:7: note: forward declaration of 'dds::pub::AnyDataWriter'
class AnyDataWriter;
      ^
include/dds/pub/DataWriter.hpp:651:33: error: variable has incomplete type 'dds::pub::AnyDataWriter'
        dds::pub::AnyDataWriter adr(*this);
                                ^
include/dds/pub/DataWriter.hpp:34:7: note: forward declaration of 'dds::pub::AnyDataWriter'
class AnyDataWriter;
      ^
2 errors generated.
```

Basically this code is trying to use a forward declaration `class AnyDataWriter;` and then later instantiate the class (`dds::pub::AnyDataWriter adr(*this);`) using `*this`. This is not supported by clang, and really it shouldn't be supported on gcc and Linux, but it is for now...

The solution I came up with was to use a forward declared function which creates a (unique/scoped) pointer to the forward declared class and use that in the code which follows. Then I found the code where the constructor for this forward declared class was and implemented the forward declared function there. I think this should be performant and work across all compilers.

The only outstanding issue is that I am using `std::unique_ptr` and I guess if you want to support non-C++11 compilers you'll need to use your internal scoped or unique pointer equivalent. Another option is to use a raw pointer and manage deletion yourself, but I thought the unique pointer was more idiomatic.

This same problem came up for `AnyDataReader` and `AnyTopic`, and my patch addresses all occurrences, and after this patch OpenSplice 6.4.0 builds on OS X for me.
