### PR TITLE
Fix compile problem with installed gsoap

### DIFF
--- a/src/services/cmsoap/makefile.mak
+++ b/src/services/cmsoap/makefile.mak
@@ -15,7 +15,7 @@ $(SOAP_MODULES): cms__soap.h
 	mv soapC.c soapC.c.orig
 	(echo '#ifndef __clang_analyzer__' ; cat soapC.c.orig ; echo '#endif') > soapC.c
 
-stdsoap2.c : $(ESCAPED_GSOAPHOME)/include/stdsoap2.c
+stdsoap2.c : $(ESCAPED_GSOAPHOME)/include/stdsoap2.h
 	(echo '#ifndef __clang_analyzer__' ; \
 	 sed -e "s/^soap_LONG642s/__soap_LONG642s/" \
                 -e "s/^soap_s2LONG64/__soap_s2LONG64/" \


### PR DESCRIPTION
Build environment: Ubuntu 16.04 on x86_64 PC
When I tried to build the opensplice v6.7 with the gsoap (by `apt-get install`) , the compilation was failed.

```bash
$> sudo apt-get install gsoap
$> source configure 
$> make -j4 
```
Output: 

```bash
...
...
gcc ../../code/q_servicelease.c                                                                                           [1833/1901]
gcc -shared -fPIC -Wl,-Bsymbolic -static-libgcc -L/home/chester/project/opensplice/lib/x86_64.linux-release -std=c99 -D_GNU_SOURCE -D
OSPL_LINUX -O3 -fno-strict-aliasing -flto -DNDEBUG -Wall -W -Wno-long-long -Wno-variadic-macros -Werror=uninitialized -D_POSIX_PTHREA
D_SEMANTICS -D_REENTRANT -DDO_HOST_BY_NAME -fPIC -Wconversion -shared -fPIC -Wl,-Bsymbolic q_osplserModule.o q_osplbuiltin.o q_transm
it.o ddsi_ssl.o q_groupset.o q_xmsg.o q_ephash.o q_qosmatch.o q_md5.o q_thread_inlines.o q_pcap.o q_init.o q_thread.o q_whc.o q_bswap
.o q_log.o q_debmon.o q_gc.o ddsi_tran.o q_murmurhash3.o q_config.o q_lat_estim.o ddsi_udp.o q_radmin.o ddsi_tcp.o q_lease.o q_bitset
_inlines.o q_receive.o q_xevent.o q_addrset.o sysdeps.o q_main.o q_plist.o q_osplser.o q_entity.o q_misc.o q_mtreader.o ddsi_ser.o q_
fill_msg_qos.o q_security.o q_bswap_inlines.o q_nwif.o q_sockwaitset.o q_time.o q_ddsi_discovery.o q_servicelease.o -lc -lm -ldl -lpt
hread -lrt -lddskernel -o libddsi2.so
rm -f /home/chester/project/opensplice/lib/x86_64.linux-release/libddsi2.so
ln      /home/chester/project/opensplice/src/services/ddsi2/bld/x86_64.linux-release/libddsi2.so /home/chester/project/opensplice/lib
/x86_64.linux-release/libddsi2.so
make[4]: Leaving directory '/home/chester/project/opensplice/src/services/ddsi2/bld/x86_64.linux-release'
make[3]: Leaving directory '/home/chester/project/opensplice/src/services/ddsi2'
make[3]: Entering directory '/home/chester/project/opensplice/src/services/cmsoap'
make[4]: Entering directory '/home/chester/project/opensplice/src/services/cmsoap/bld/x86_64.linux-release'
soapcpp2 -c ../../code/cms__soap.h >soapcpp.output 2>&1 || { xc=../../code/cms__soap.h ; cat soapcpp.output ; exit c ; }
mv soapC.c soapC.c.orig
(echo '#ifndef __clang_analyzer__' ; cat soapC.c.orig ; echo '#endif') > soapC.c
DEP soapServer.c
DEP soapC.c
DEP ../../code/cms_soapThread.c
DEP ../../code/cms_soap2.c
DEP ../../code/cms_client.c
DEP ../../code/cms_service.c
DEP ../../code/cms_configuration.c
DEP ../../code/cms_thread.c
DEP ../../code/cmsoap.c
make[4]: *** No rule to make target '/usr/include/stdsoap2.c', needed by 'stdsoap2.c'.  Stop.
make[4]: Leaving directory '/home/chester/project/opensplice/src/services/cmsoap/bld/x86_64.linux-release'
makefile:4: recipe for target 'link' failed
make[3]: *** [link] Error 2
make[3]: Leaving directory '/home/chester/project/opensplice/src/services/cmsoap'
/home/chester/project/opensplice/setup/makefiles/subsystem.mak:5: recipe for target 'cmsoap.ss_link' failed
make[2]: *** [cmsoap.ss_link] Error 2
make[2]: Leaving directory '/home/chester/project/opensplice/src/services'
/home/chester/project/opensplice/setup/makefiles/subsystem.mak:5: recipe for target 'services.ss_link' failed
make[1]: *** [services.ss_link] Error 2
make[1]: Leaving directory '/home/chester/project/opensplice/src'
/home/chester/project/opensplice/setup/makefiles/subsystem.mak:5: recipe for target 'src.ss_link' failed
make: *** [src.ss_link] Error 2
```
Solution: by fixing the makefile
