### PR TITLE
Fix java version detection for some recent JDK versions (e.g. OpenJDK 10)

### DIFF
--- a/bin/checkconf
+++ b/bin/checkconf
@@ -711,7 +711,7 @@ javac_check_darwin ()
     set_var JAVA_HOME "$JAVA_HOME"
 
     JAVAC_EXE=javac
-    "$JAVAC_EXE" -version 2> javac.ver
+    "$JAVAC_EXE" -version 2>&1 > javac.ver
     JAVAC_REAL_VERSION=`cat javac.ver | grep "javac" | head -1 | awk '{ print $2 }'`
     JAVAC_VERSION=`echo $JAVAC_REAL_VERSION | awk -F'.' '{ print $1"."$2 }' | sed -e 's;\.;0;g'`
     rm -f javac.ver
@@ -785,7 +785,7 @@ javac_check ()
         JAVAC_EXE=`readlink -f "$T_JAVAC_EXE"`
     fi
 
-    "$JAVAC_EXE" -version 2> javac.ver
+    "$JAVAC_EXE" -version 2>&1 > javac.ver
     JAVAC_REAL_VERSION=`cat javac.ver | grep "javac" | head -1 | awk '{ print $2 }'`
     JAVAC_VERSION=`echo $JAVAC_REAL_VERSION | awk -F'.' '{ print $1"."$2 }' | sed -e 's;\.;0;g'`
     rm -f javac.ver


### PR DESCRIPTION
Newer versions of Java (for example, OpenJDK 10) when executing the command `java -version` return the version number on STDOUT instead of STDERR but the `configure` script was only reading from the second. This fix reads the version number from both.