### PR TITLE
fix generic copy routines for unions

### DIFF
--- a/src/api/dcps/sac/code/sac_genericCopyCache.c
+++ b/src/api/dcps/sac/code/sac_genericCopyCache.c
@@ -213,15 +213,32 @@ userSizeCorrection (
             size += userSizeCorrection(c_memberType(member));
         }
     break;
-    case M_UNION:
+    case M_UNION: {
+        unsigned int unionValueSizeUser = 0;
+        unsigned int unionValueSizeSHM = 0;
+        unsigned int align = 1;
         for (i = 0; i < c_unionUnionCaseCount(actual); i++) {
+            unsigned a;
             ucase = c_unionUnionCase(actual, i);
-            cs = userSizeCorrection(c_unionCaseType(ucase));
-            if ( cs > size ) {
-                size = cs;
+            a = c_unionCaseType (ucase)->alignment;
+            if (a > align) {
+                align = a;
             }
         }
+        for (i = 0; i < c_unionUnionCaseCount(actual); i++) {
+            ucase = c_unionUnionCase(actual, i);
+            cs = DDS_cacheObjectUserSize(c_unionCaseType(ucase));
+            if (cs > unionValueSizeUser) {
+                unionValueSizeUser = cs;
+            }
+            cs = c_unionCaseType(ucase)->size;
+            if (cs > unionValueSizeSHM) {
+                unionValueSizeSHM = cs;
+            }
+        }
+        size = ((unionValueSizeUser + align - 1) & ~(align - 1)) - ((unionValueSizeSHM + align - 1) & ~(align - 1));
     break;
+    }
     case M_COLLECTION:
         switch ( c_collectionTypeKind(actual) ) {
         case OSPL_C_SEQUENCE:

--- a/src/api/dcps/sac/code/sac_genericCopyIn.c
+++ b/src/api/dcps/sac/code/sac_genericCopyIn.c
@@ -1628,6 +1628,9 @@ DDS_cfoiUnion (
     cuh = (DDSCopyUnion *)ch;
 
     context.dst = dstUnion;
+    context.base = ctx->base;
+    context.dst_offset = 0;
+    context.src_correction = 0;
     cdh = DDSCopyUnionDiscriminantObject (cuh);
     ciFromUnion[cdh->copyType] (cdh, srcUnion, &context);
 


### PR DESCRIPTION
There is a bit of a problem in using the generic copy routines in combination with unions: the differences in representation between shared memory and C mapping are not correctly accounted for for the various union cases.