### PR TITLE
Export typedef copy methods

### DIFF
--- a/setup/x86_64.win64-default.mak
+++ b/setup/x86_64.win64-default.mak
@@ -91,12 +91,12 @@ else
 else
 # VS2015
    VS_INCLUDE =  -I"$(VS_HOME)/VC/include"
-   VS_INCLUDE += -I"$(WINDOWSSDKDIR)/Include/10.0.10150.0/ucrt"
+   VS_INCLUDE += -I"$(WINDOWSSDKDIR)/Include/10.0.18362.0/ucrt"
    VS_INCLUDE += -I"$(WINDOWSSDKDIR)/../8.1/Include/um"
    VS_INCLUDE += -I"$(WINDOWSSDKDIR)/../8.1/Include/shared"
    
    VS_LIB_FLAGS += -L"$(VS_HOME)/VC/lib/amd64"
-   VS_LIB_FLAGS += -L"$(WINDOWSSDKDIR)/Lib/10.0.10150.0/ucrt/x64"
+   VS_LIB_FLAGS += -L"$(WINDOWSSDKDIR)/Lib/10.0.18362.0/ucrt/x64"
    VS_LIB_FLAGS += -L"$(WINDOWSSDKDIR)/../8.1/Lib/winv6.3/um/x64"
    VS_LIB_FLAGS += -L"$(WINDOWSSDKDIR)/../8.1/lib/x64"
 endif


### PR DESCRIPTION
Fixes https://github.com/ADLINK-IST/opensplice/issues/131

Built with MSVC 14.2 (only).
Added copyIn and copyOut declarations for typedefs to match the declarations used for structs.
Added for both genSpliceType and genISOCxx2SpliceType, not sure if there are other places to add it.
Removed unnecessary references to structs and classes on the param types from the struct code, because the typedefs don't just deal with structs, but I'm not sure if this will cause issues with GCC etc.