### PR TITLE
os_free should used rather than free

### DIFF
--- a/src/database/database/code/q_parser.y
+++ b/src/database/database/code/q_parser.y
@@ -308,7 +308,7 @@ ID:
           /* frees dynamically malloced variable length string value
              allocated by the lexical scanner.
           */
-          free($1);
+          os_free($1);
         }
     ;
 
@@ -318,21 +318,21 @@ scopedName:
           /* frees dynamically malloced variable length string value
              allocated by the lexical scanner.
           */
-          free($1);
+          os_free($1);
         }
     | DOUBLECOLON identifier
         { $$ = List1(q_newId($2));
           /* frees dynamically malloced variable length string value
              allocated by the lexical scanner.
           */
-          free($2);
+          os_free($2);
         }
     | scopedName DOUBLECOLON identifier
         { $$ = q_append($1,q_newId($3));
           /* frees dynamically malloced variable length string value
              allocated by the lexical scanner.
           */
-          free($3);
+          os_free($3);
         }
     ;
 
@@ -368,7 +368,7 @@ literal:
           /* frees dynamically malloced variable length string value
              allocated by the lexical scanner.
           */
-          free($1);
+          os_free($1);
         }
     | DOLLAR ulonglongLiteral
         { $$ = q_newVar($2);

--- a/src/kernel/code/v_parser.y
+++ b/src/kernel/code/v_parser.y
@@ -227,7 +227,7 @@ topicName:
       ident
         { $$ = q_newId($1);
           ut_stackPush(context->exprStack, $$);
-          free($1);
+          os_free($1);
         }
     ;
 
@@ -354,14 +354,14 @@ field:
       IDENTIFIER
         { $$ = q_newId($1);
           ut_stackPush(context->exprStack, $$);
-          free($1);
+          os_free($1);
         }
     | FIELDNAME
         { q_list list = splitFieldname($1);
           assert(list != NULL);
           $$ = L1(Q_EXPR_PROPERTY,list); ;
           ut_stackPush(context->exprStack, $$);
-          free($1);
+          os_free($1);
         }
     ;
 
@@ -402,12 +402,12 @@ parameter:
     | STRINGVALUE
         { $$ = q_newStr($1);
           ut_stackPush(context->exprStack, $$);
-          free($1);
+          os_free($1);
         }
     | ENUMERATEDVALUE
         { $$ = q_newStr($1);
           ut_stackPush(context->exprStack, $$);
-          free($1);
+          os_free($1);
         }
     | PARAM
         { $$ = q_newVar($1);


### PR DESCRIPTION
os_free's behavior may be different from free, so if the buffer is allocated using os_malloc, it should be freed with os_free rather than free.