### PR TITLE
idlpp: Fix that prevents more characters than specified to be trimmed from file name.

### DIFF
--- a/src/abstraction/os/common/code/os_string.c
+++ b/src/abstraction/os/common/code/os_string.c
@@ -273,6 +273,7 @@ os_str_rtrim (
     const os_char *trim)
 {
     os_char *lim, *ptr;
+    os_size_t excess_chars;
 
     assert (str != NULL);
 
@@ -281,11 +282,12 @@ os_str_rtrim (
     }
 
     lim = os_strrchrs (str, trim, OS_FALSE);
+    excess_chars = strlen(lim) - strlen(trim);
     if (lim != NULL) {
         /* if byte following last occurrence of non-trim character is null
            terminating byte, nothing needs to be replaced */
         if (lim[1] != '\0') {
-            ptr = os_strndup (str, (os_size_t)((lim - str) + 1));
+            ptr = os_strndup (str, (os_size_t)((lim - str) + excess_chars));
         } else {
             ptr = (os_char *)str;
         }


### PR DESCRIPTION
We have noticed that malformed includes are generated for isoc++2 in some cases when using `-o maintain-include-namespace`.
Steps to reproduce:

1. Create two files:

main.idl
```IDL
include <ospl.idl>
struct foo {
  bar baz;
}
```

ospl.idl
```IDL
typedef octet bar;
```

3. Execute `idlpp -l isocpp2 -o maintain-include-namespace main.idl`

4. Notice that the trailing letter l (lower case L) has been stripped of the included file:
main.h
```
...
#include "osp.h"
...
```

The implementation of trimming of the file name extension `.idl` is implemented as "remove any of the characters '.idl' until none of them is left at the end of the string". This results in the behavior described above.

Therefore I propose a simple fix that limits the number of characters removed to the length of the string passed to the `os_str_rtrim` function.